### PR TITLE
fix: handle comments at the end of an action

### DIFF
--- a/up_lpg/lpg_planner.py
+++ b/up_lpg/lpg_planner.py
@@ -76,7 +76,7 @@ class LPGEngine(PDDLPlanner):
                         parameters.append(problem.environment.expression_manager.ObjectExp(p_correct))
                     if tt:
                         start = re.match(r'^([\d.]+):', line).group(1)
-                        dur = re.match(r'^[\d.]+:\s*\(\s*[\w?-]+((\s+[\w?-]+)*)\s*\)\s*\[([\d.]+)\]$', line).group(3)
+                        dur = re.match(r'^[\d.]+:\s*\(\s*[\w?-]+((\s+[\w?-]+)*)\s*\)\s*\[([\d.]+)\]', line).group(3)
                         actions.append((Fraction(start), up.plans.ActionInstance(action, tuple(parameters)), Fraction(dur)))
                     else:
                         actions.append(up.plans.ActionInstance(action, tuple(parameters)))


### PR DESCRIPTION
Got a plan with the line `0.0013:   (T_2_0) [39.0000] ;; InputAct` in the generated plan.
The regex raises an `AttributeError` since no match were found because of the comment at the end of the line.